### PR TITLE
Fix home link clicking on mouse hover

### DIFF
--- a/core/templates/index.html
+++ b/core/templates/index.html
@@ -42,7 +42,7 @@
             </div>
         </div>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav nav-dropdown nav-right" data-app-modern-menu="true"><li class="nav-item dropdown">
+            <ul class="navbar-nav nav-dropdown nav-right" data-app-modern-menu="true"><li class="nav-item">
                     <a class="text-white display-4" href="/">Home</a>
                 </li><li class="nav-item">
                     <a class="text-white display-4" href="payments">Payments</a>

--- a/core/templates/payments.html
+++ b/core/templates/payments.html
@@ -43,7 +43,7 @@
             </div>
         </div>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav nav-dropdown nav-right" data-app-modern-menu="true"><li class="nav-item dropdown">
+            <ul class="navbar-nav nav-dropdown nav-right" data-app-modern-menu="true"><li class="nav-item">
                     <a class="text-white display-4" href="/">Home</a>
                 </li><li class="nav-item">
                     <a class="text-white display-4" href="payments">Payments</a>


### PR DESCRIPTION
When the user hovers over the "Home" link, it's treated as a mouse click.  This is because of the `dropdown` class that causes a click in JS.