### PR TITLE
block catch up sleep extended

### DIFF
--- a/core/tbw.py
+++ b/core/tbw.py
@@ -477,7 +477,7 @@ if __name__ == '__main__':
 
                     print('\n' + 'Waiting for the next block....' + '\n')
                     # sleep 2 seconds between allocations
-                    time.sleep(2)
+                    time.sleep(10)
 
             arkdb.close_connection()
             # pause 30 seconds between runs


### PR DESCRIPTION
making sleep 10 for catch up. v3 api rate limiter may cause issues. if all ark based chains move to v3 this would have to change anyways and can't hurt to be longer.