### PR TITLE
Solar: Change psql connection from tcp socket to unix socket

### DIFF
--- a/core/network/network.py
+++ b/core/network/network.py
@@ -17,6 +17,7 @@ class Network():
          self.wif = int(os.getenv("WIF"))
          self.api_port = os.getenv("API_PORT")
          self.database = os.getenv("DATABASE")
+         self.database_host = os.getenv("DATABASE_HOST")
          self.database_user = os.getenv("DATABASE_USER")
          self.database_password = os.getenv("DATABASE_PASSWORD")
          self.delegates = int(os.getenv("DELEGATES"))

--- a/core/network/solar_testnet
+++ b/core/network/solar_testnet
@@ -4,6 +4,7 @@ VERSION = 30
 WIF = 252
 API_PORT = 6003
 DATABASE = "solar_testnet"
+DATABASE_HOST= "${HOME}/.local/share/solar-core/testnet/database/"
 DATABASE_USER = "null"
 DATABASE_PASSWORD = "password"
 DELEGATES = 53

--- a/core/tbw.py
+++ b/core/tbw.py
@@ -422,7 +422,11 @@ if __name__ == '__main__':
     
     # initialize db connection
     # get database
-    arkdb = ArkDB(network.database, data.database_user, network.database_password, data.public_key)
+    arkdb = ArkDB(network.database,
+                  network.database_host,
+                  data.database_user,
+                  network.database_password,
+                  data.public_key)
     
     #conversion check for pre 2.3 databases
     conversion_check()

--- a/core/util/ark.py
+++ b/core/util/ark.py
@@ -1,19 +1,22 @@
 import psycopg2
 
 class ArkDB:
-    def __init__(self, db, u, pw, pk):
+    def __init__(self, db, dbh, u, pw, pk):
         self.db=db
         self.user=u
         self.password=pw
         self.PublicKey=pk
-    
+        if not dbh:
+            self.host = 'localhost'
+        else:
+            self.host = dbh
     
     def open_connection(self):
         self.connection = psycopg2.connect(
             dbname = self.db,
             user = self.user,
             password= self.password,
-            host='localhost',
+            host=self.host,
             port='5432')
             
         self.cursor=self.connection.cursor()


### PR DESCRIPTION
Solar core by default, on newer version ( 3.2.0 ), use postgreSQL which doesn't listen on a TCP socket, but only on unix socket.
